### PR TITLE
Fix custom cf command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,5 @@ cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 if [[ -z "$INPUT_CF_COMMAND" ]]; then
     cf v3-zdt-push -f "$MANIFEST"
 else
-    cf $INPUT_CF_COMMAND
+    cf "$INPUT_CF_COMMAND"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ cf auth "$INPUT_CF_USERNAME" "$INPUT_CF_PASSWORD"
 
 cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 
-if [[ ! -r "$INPUT_CF_COMMAND" ]]; then
+if [[ ! -z "$INPUT_CF_COMMAND" ]]; then
     cf v3-zdt-push -f "$MANIFEST"
 else
     cf $INPUT_CF_COMMAND

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ cf auth "$INPUT_CF_USERNAME" "$INPUT_CF_PASSWORD"
 
 cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 
-if [[ ! -z "$INPUT_CF_COMMAND" ]]; then
+if [[ -z "$INPUT_CF_COMMAND" ]]; then
     cf v3-zdt-push -f "$MANIFEST"
 else
     cf $INPUT_CF_COMMAND


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix syntax issue with using an alternative command, not `cf v3-zdt-push -f "$MANIFEST"`. 

## Security considerations
- This is a syntax change of existing functionality for custom commands, we can assume the risk of this flexibility in the Github Action is acceptable (we control who can create PRs and if PR branches can run the action before review and merging).
- I am manually ran [shellcheck](https://www.shellcheck.net/) to properly escape some variables and ensure security of style. Perhaps you would humor a pre-commit hook configuration setup for that in the future?