### PR TITLE
Do not actually quote cf command args.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,5 +15,6 @@ cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 if [[ -z "$INPUT_CF_COMMAND" ]]; then
     cf v3-zdt-push -f "$MANIFEST"
 else
-    cf "$INPUT_CF_COMMAND"
+    # shellcheck disable=SC2086
+    cf $INPUT_CF_COMMAND
 fi


### PR DESCRIPTION
As nice as it is to follow shellcheck guidelines, in this case you want
to pass in the arguments as an unquoted string and allow the dev to
quote individual arguments accordingly.

## Changes proposed in this pull request:

- Fix syntax error instigated by  cloud-gov/cg-cli-tools#4

## Security considerations

- Same concerns as referenced in the aforementioned PR, and par for the course.
