### PR TITLE
Make useful for invoking scripts, not just subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The default action is to do a `cf push -f manifest.yml --strategy rolling`.
 
 You can also supply:
 
+- `cf_api:` to specify a Cloud Foundry API endpoint (instead of the default `api.fr.cloud.gov`)
 - `cf_manifest:` to use a different manifest file (instead of the default `manifest.yml`)
 - `cf_vars_file:` to [specify values for variables in the manifest file](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution)
 - `cf_command:` to specify a CF sub-command to run (instead of the default `push -f $MANIFEST -vars-file $VARS_FILE --strategy rolling`)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can also supply:
 
 - `cf_manifest:` to use a different manifest file (instead of the default `manifest.yml`)
 - `cf_vars_file:` to [specify values for variables in the manifest file](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution)
-- `cf_command:` to specify a CF sub command to run (instead of the default `push -f $MANIFEST -vars-file $VARS_FILE --strategy rolling`)
+- `cf_command:` to specify a CF sub-command to run (instead of the default `push -f $MANIFEST -vars-file $VARS_FILE --strategy rolling`)
 - `command:` to specify another command altogether (for example: a script which checks if required services are present and creates them if they're missing)
 
 ## A note on versions

--- a/README.md
+++ b/README.md
@@ -43,16 +43,21 @@ jobs:
       - name: Deploy to cloud.gov
         uses: cloud-gov/cg-cli-tools@main
         with: 
-          cf_api: https://api.fr.cloud.gov
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: your-org
           cf_space: your-space
-          cf_command: push
 
 ```
 
-You can optionally add the name of a manifest file (default is `manifest.yml`), use a `vars.yml` file with your push, or specify a command to run instead of `cf push` (e.g., `cf push APP_NAME --strategy rolling` for a zero downtime deploy).
+The default action is to do a `cf push -f manifest.yml --strategy rolling`.
+
+You can also supply:
+
+- `cf_manifest:` to use a different manifest file (instead of the default `manifest.yml`)
+- `cf_vars_file:` to [specify values for variables in the manifest file](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution)
+- `cf_command:` to specify a CF sub command to run (instead of the default `push -f $MANIFEST -vars-file $VARS_FILE --strategy rolling`)
+- `command:` to specify another command altogether (for example: a script which checks if required services are present and creates them if they're missing)
 
 ## A note on versions
 

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: "Cloud.gov CF CLI Tools"
 description: "Deploy and manage apps on cloud.gov"
 inputs:
   cf_api:
-    description: "Target API endpoint"
-    required: true
+    description: "Target API endpoint. Defaults to api.fr.cloud.gov."
+    required: false
   cf_username:
     description: "Username for API authentication"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,10 @@ inputs:
     description: "Name of the vars file to use"
     required: false
   cf_command:
-    description: "CF CLI command to run"
+    description: "CF CLI subcommand to run. Mutually exclusive with 'command:'."
+    required: false
+  command:
+    description: "Command to run. Mutually exclusive with 'cf_command:'."
     required: false
 runs:
   using: "docker"

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@ inputs:
     required: true
   cf_org:
     description: "Target organization"
-    required: false
+    required: true
   cf_space:
     description: "Target space"
-    required: false
+    required: true
   cf_manifest:
     description: "Manifest file name to use for pushing. Defaults to 'manifest.yml'."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "Target space"
     required: false
   cf_manifest:
-    description: "Manifest file name"
+    description: "Manifest file name to use for pushing. Defaults to 'manifest.yml'."
     required: false
   cf_vars_file:
     description: "Name of the vars file to use"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,9 @@ if [[ ! -r "$MANIFEST" ]]; then
   exit 1
 fi
 
+CF_API=${INPUT_CF_API:-api.fr.cloud.gov}
 # Authenticate and target CF org and space.
-cf api "$INPUT_CF_API"
+cf api "$CF_API"
 cf auth "$INPUT_CF_USERNAME" "$INPUT_CF_PASSWORD"
 cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,12 @@ cf api "$CF_API"
 cf auth "$INPUT_CF_USERNAME" "$INPUT_CF_PASSWORD"
 cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 
+# If they specified a full command, run it
+if [[ -n "$INPUT_COMMAND" ]]; then
+  echo "Running command: $INPUT_COMMAND"
+  exec $INPUT_COMMAND
+fi
+
 # If they specified a cf CLI subcommand, run it
 if [[ -n "$INPUT_CF_COMMAND" ]]; then
   echo "Running command: $INPUT_CF_COMMAND"


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix: The org and space are not optional
- fix: Using a non-default manifest file and a vars file shouldn't be mutually exclusive
- feature: Defaults the API to api.fr.cloud.gov and makes that input optional
- feature: You can specify a `command` instead of a `cf_command`. 
  - You can specify any command you want, which expands the usefulness of the Action.
  - Existing behavior (run a subcommand with `cf_command` or `push` by default) is unchanged
- feature: The default `push` uses `--strategy rolling` to reduce downtime during deploys

## Security considerations

[Note the any security considerations here, or make note of why there are none]
None that we know of.