### PR TITLE
Use upstream docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,3 @@
-FROM ubuntu:latest
-
-RUN apt-get update -y 
-RUN apt-get install -y wget gnupg2
-RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
-RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-RUN apt-get update -y 
-RUN apt-get install cf7-cli -y
-
+FROM cloudfoundry/cli:7
 ADD entrypoint.sh /entrypoint.sh
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM cloudfoundry/cli:7
+FROM cloudfoundry/cli:8
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- breaking: Rebased on the official upstream alpine image maintained by the CF CLI team
- feature: Update to CF CLI v8 

## Notes: 

There haven't ever been any release tags on this repository. There should be, especially since this PR will break functionality for people who rely on the fact that it previously derived from `ubuntu:latest`. So call this `1.0.0`, with a major change from the previously implied `0.x.x`.

The first commit (switching the FROM image) should be tagged as `1.0.0-v7`, and the second commit (updating the CF CLI version) should be tagged as `1.0.0-v8`. This should probably happen _before_ https://github.com/cloud-gov/cg-cli-tools/pull/10... Then that PR can introduce `1.1.0-v7` and `1.1.0-v8` (since it adds the `command:` feature).

## Security considerations

None that we know of.