### PR TITLE
Eval and run command strings rather than exec

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,13 +9,15 @@ cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 # If they specified a full command, run it
 if [[ -n "$INPUT_COMMAND" ]]; then
   echo "Running command: $INPUT_COMMAND"
-  exec $INPUT_COMMAND
+  eval $INPUT_COMMAND
+  exit
 fi
 
 # If they specified a cf CLI subcommand, run it
 if [[ -n "$INPUT_CF_COMMAND" ]]; then
   echo "Running command: $INPUT_CF_COMMAND"
-  exec cf $INPUT_CF_COMMAND
+  eval cf $INPUT_CF_COMMAND
+  exit
 fi
 
 # Otherwise, assume they want to do a cf push.


### PR DESCRIPTION
To support command strings that contain quoted sub-commands, use `eval` rather than directly `exec`'ing the command string. (Bash passes the raw string, quotes included, to exec)

This PR was created to enable the usage here: https://github.com/GSA/site-scanning-engine/blob/main/.github/workflows/ingest.yml#L27

## Changes proposed in this pull request:

- Eval command strings
- Exit process with `cf` exit code

## Security considerations

If I understand correctly, there are no additional concerns over and above directly exec'ing the command string.