### PR TITLE
Execute command string in a shell

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 # If they specified a full command, run it
 if [[ -n "$INPUT_COMMAND" ]]; then
   echo "Running command: $INPUT_COMMAND"
-  exec $INPUT_COMMAND
+  exec bash -c "$INPUT_COMMAND"
 fi
 
 # If they specified a cf CLI subcommand, run it


### PR DESCRIPTION
## Changes proposed in this pull request:

- Allows for compound commands, not just script invocations
  - Previously the command "echo hey && echo hi" would fail. Now it works!

## Security considerations

None, given that this is run in GH Action workflows where the command supplied and all the data it works on are in the control of the workflow author.