### PR TITLE
Execute command string in a shell (CLI v8 version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y wget gnupg2
 RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
 RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 RUN apt-get update -y 
-RUN apt-get install cf7-cli -y
+RUN apt-get install cf8-cli -y
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 # If they specified a full command, run it
 if [[ -n "$INPUT_COMMAND" ]]; then
   echo "Running command: $INPUT_COMMAND"
-  exec $INPUT_COMMAND
+  exec bash -c "$INPUT_COMMAND"
 fi
 
 # If they specified a cf CLI subcommand, run it


### PR DESCRIPTION
## Changes proposed in this pull request:

- Allows for compound commands, not just script invocations
  - Previously the command "echo hey && echo hi" would fail. Now it works!

## Security considerations

None, given that this is run in GH Action workflows where the command supplied and all the data it works on are in the control of the workflow author.