### PR TITLE
Derive from upstream CF CLI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt-get update -y 
-RUN apt-get install -y wget gnupg2
-RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
-RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-RUN apt-get update -y 
-RUN apt-get install cf8-cli -y
-
+FROM cloudfoundry/cli:latest
 ADD entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use the upstream CF CLI image, which should remove the dependency on the availability of packages.cloudfoundry.org at the time the action runs (and builds this image).

## Security considerations

No security considerations. If anything this improves the supply-chain story since the CF CLI binary is only ever replaced when there's a new upstream image on Docker Hub.