### PR TITLE
add bash shell to image and use /bin/bash for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM cloudfoundry/cli:latest
+
 ADD entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+RUN apk update
+RUN apk upgrade
+RUN apk add bash
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixes for #20. #20 moved to `cloudfoundry/cli` as a base image, which broke the entrypoint.sh script since it relies on a `bash` shell.

`cloudfoundry/cli` is based on Alpine which has no `bash` shell by default. This PR adds a `bash` shell to the image and uses it by default for the entrypoint.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No meaningful security changes here
