### PR TITLE
Fix missing BASH in Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
 FROM cloudfoundry/cli:latest
-
+RUN apk update && apk upgrade && apk add --no-cache bash
 ADD entrypoint.sh /entrypoint.sh
-
-RUN apk update
-RUN apk upgrade
-RUN apk add bash
-
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
The action's entrypoint, and likely users of the action, need this.

## Changes proposed in this pull request:

- Include the BASH binary and make it available for shell scripts

## Security considerations

None, we've already stripped the image to just the Alpine image and BASH use in Alpine is ubiquitous.