### PR TITLE
add coreutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM cloudfoundry/cli:latest
-RUN apk update && apk upgrade && apk add --no-cache bash jq curl grep
+RUN apk update && apk upgrade && apk add --no-cache bash jq curl grep coreutils
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
Similar situation as in https://github.com/cloud-gov/cg-cli-tools/pull/23#issuecomment-1817218527, the `date` command in busybox does not recognize date formatted as `2024-02-01T17:02:55.83+0000`. This is the common format from any cloud.gov app logs. The `GNU date` from `coreutils` works well. 

## Changes proposed in this pull request:

- apk add --no-cache coreutils

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

coreutils is a well-understood CLI utility that are being pulled from the upstream Alpine repository, which is updated frequently.
