### PR TITLE
Explicitly use cf v8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudfoundry/cli:latest
+FROM cloudfoundry/cli:8
 RUN apk update && apk upgrade && apk add --no-cache bash jq curl grep coreutils
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- The 'latest' tag is currently pointing to cf cli v7.
- This explicitly pulls version 8.
- This matches the docs: https://github.com/cloud-gov/cg-cli-tools/blob/d6807f2818c9d985127e6eaab1aa142a2e2f5213/Dockerfile#L1C6-L1C29

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. We are using the version we say we are using.
